### PR TITLE
Potential fix for code scanning alert no. 29: Useless assignment to local variable

### DIFF
--- a/third-party/github.com/letsencrypt/boulder/va/tlsalpn.go
+++ b/third-party/github.com/letsencrypt/boulder/va/tlsalpn.go
@@ -173,7 +173,7 @@ func (va *ValidationAuthorityImpl) getChallengeCert(
 				return errors.New("no certificates provided")
 			}
 			// Parse the presented certificate.
-			cert, err := x509.ParseCertificate(certificates[0])
+			_, err := x509.ParseCertificate(certificates[0])
 			if err != nil {
 				return fmt.Errorf("failed to parse certificate: %w", err)
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/AKA-NETWORK/cli/security/code-scanning/29](https://github.com/AKA-NETWORK/cli/security/code-scanning/29)

To fix the issue, the unnecessary assignment to `cert` should be removed. Since the `cert` variable is not used after being assigned, and the `err` variable is already being handled correctly, we can replace the assignment with a direct call to `x509.ParseCertificate` that only checks for errors. This ensures the code remains clean and avoids confusion about unused variables.

Specific changes to make:
- Replace the assignment `cert, err := x509.ParseCertificate(certificates[0])` with `_ , err := x509.ParseCertificate(certificates[0])` to clarify that the result of the function other than the error is intentionally ignored.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
